### PR TITLE
renames [Aa]ccountConnectionFlow to [Aa]ccountCollectionFlow

### DIFF
--- a/modern-treasury-java-core/src/main/kotlin/com/moderntreasury/api/models/AccountCollectionFlow.kt
+++ b/modern-treasury-java-core/src/main/kotlin/com/moderntreasury/api/models/AccountCollectionFlow.kt
@@ -16,9 +16,9 @@ import java.time.OffsetDateTime
 import java.util.Objects
 import java.util.Optional
 
-@JsonDeserialize(builder = AccountConnectionFlow.Builder::class)
+@JsonDeserialize(builder = AccountCollectionFlow.Builder::class)
 @NoAutoDetect
-class AccountConnectionFlow
+class AccountCollectionFlow
 private constructor(
     private val id: JsonField<String>,
     private val object_: JsonField<String>,
@@ -121,7 +121,7 @@ private constructor(
     @ExcludeMissing
     fun _additionalProperties(): Map<String, JsonValue> = additionalProperties
 
-    fun validate(): AccountConnectionFlow = apply {
+    fun validate(): AccountCollectionFlow = apply {
         if (!validated) {
             id()
             object_()
@@ -144,7 +144,7 @@ private constructor(
             return true
         }
 
-        return other is AccountConnectionFlow &&
+        return other is AccountCollectionFlow &&
             this.id == other.id &&
             this.object_ == other.object_ &&
             this.liveMode == other.liveMode &&
@@ -179,7 +179,7 @@ private constructor(
     }
 
     override fun toString() =
-        "AccountConnectionFlow{id=$id, object_=$object_, liveMode=$liveMode, createdAt=$createdAt, updatedAt=$updatedAt, clientToken=$clientToken, status=$status, counterpartyId=$counterpartyId, externalAccountId=$externalAccountId, paymentTypes=$paymentTypes, additionalProperties=$additionalProperties}"
+        "AccountCollectionFlow{id=$id, object_=$object_, liveMode=$liveMode, createdAt=$createdAt, updatedAt=$updatedAt, clientToken=$clientToken, status=$status, counterpartyId=$counterpartyId, externalAccountId=$externalAccountId, paymentTypes=$paymentTypes, additionalProperties=$additionalProperties}"
 
     companion object {
 
@@ -201,18 +201,18 @@ private constructor(
         private var additionalProperties: MutableMap<String, JsonValue> = mutableMapOf()
 
         @JvmSynthetic
-        internal fun from(accountConnectionFlow: AccountConnectionFlow) = apply {
-            this.id = accountConnectionFlow.id
-            this.object_ = accountConnectionFlow.object_
-            this.liveMode = accountConnectionFlow.liveMode
-            this.createdAt = accountConnectionFlow.createdAt
-            this.updatedAt = accountConnectionFlow.updatedAt
-            this.clientToken = accountConnectionFlow.clientToken
-            this.status = accountConnectionFlow.status
-            this.counterpartyId = accountConnectionFlow.counterpartyId
-            this.externalAccountId = accountConnectionFlow.externalAccountId
-            this.paymentTypes = accountConnectionFlow.paymentTypes
-            additionalProperties(accountConnectionFlow.additionalProperties)
+        internal fun from(accountCollectionFlow: AccountCollectionFlow) = apply {
+            this.id = accountCollectionFlow.id
+            this.object_ = accountCollectionFlow.object_
+            this.liveMode = accountCollectionFlow.liveMode
+            this.createdAt = accountCollectionFlow.createdAt
+            this.updatedAt = accountCollectionFlow.updatedAt
+            this.clientToken = accountCollectionFlow.clientToken
+            this.status = accountCollectionFlow.status
+            this.counterpartyId = accountCollectionFlow.counterpartyId
+            this.externalAccountId = accountCollectionFlow.externalAccountId
+            this.paymentTypes = accountCollectionFlow.paymentTypes
+            additionalProperties(accountCollectionFlow.additionalProperties)
         }
 
         fun id(id: String) = id(JsonField.of(id))
@@ -328,8 +328,8 @@ private constructor(
             this.additionalProperties.putAll(additionalProperties)
         }
 
-        fun build(): AccountConnectionFlow =
-            AccountConnectionFlow(
+        fun build(): AccountCollectionFlow =
+            AccountCollectionFlow(
                 id,
                 object_,
                 liveMode,

--- a/modern-treasury-java-core/src/main/kotlin/com/moderntreasury/api/models/AccountCollectionFlowListPage.kt
+++ b/modern-treasury-java-core/src/main/kotlin/com/moderntreasury/api/models/AccountCollectionFlowListPage.kt
@@ -25,7 +25,7 @@ private constructor(
 
     fun response(): Response = response
 
-    fun items(): List<AccountConnectionFlow> = response().items()
+    fun items(): List<AccountCollectionFlow> = response().items()
 
     fun perPage(): String = response().perPage()
 
@@ -99,7 +99,7 @@ private constructor(
     @NoAutoDetect
     class Response
     constructor(
-        private val items: JsonField<List<AccountConnectionFlow>>,
+        private val items: JsonField<List<AccountCollectionFlow>>,
         private val perPage: String,
         private val afterCursor: String,
         private val additionalProperties: Map<String, JsonValue>,
@@ -107,14 +107,14 @@ private constructor(
 
         private var validated: Boolean = false
 
-        fun items(): List<AccountConnectionFlow> = items.getNullable("items") ?: listOf()
+        fun items(): List<AccountCollectionFlow> = items.getNullable("items") ?: listOf()
 
         fun perPage(): String = perPage
 
         fun afterCursor(): String = afterCursor
 
         @JsonProperty("items")
-        fun _items(): Optional<JsonField<List<AccountConnectionFlow>>> = Optional.ofNullable(items)
+        fun _items(): Optional<JsonField<List<AccountCollectionFlow>>> = Optional.ofNullable(items)
 
         @JsonAnyGetter
         @ExcludeMissing
@@ -153,7 +153,7 @@ private constructor(
 
         class Builder {
 
-            private var items: JsonField<List<AccountConnectionFlow>> = JsonMissing.of()
+            private var items: JsonField<List<AccountCollectionFlow>> = JsonMissing.of()
             private var perPage: String? = null
             private var afterCursor: String? = null
             private var additionalProperties: MutableMap<String, JsonValue> = mutableMapOf()
@@ -166,10 +166,10 @@ private constructor(
                 this.additionalProperties.putAll(page.additionalProperties)
             }
 
-            fun items(items: List<AccountConnectionFlow>) = items(JsonField.of(items))
+            fun items(items: List<AccountCollectionFlow>) = items(JsonField.of(items))
 
             @JsonProperty("items")
-            fun items(items: JsonField<List<AccountConnectionFlow>>) = apply { this.items = items }
+            fun items(items: JsonField<List<AccountCollectionFlow>>) = apply { this.items = items }
 
             fun perPage(perPage: String) = apply { this.perPage = perPage }
 
@@ -193,9 +193,9 @@ private constructor(
     class AutoPager
     constructor(
         private val firstPage: AccountCollectionFlowListPage,
-    ) : Iterable<AccountConnectionFlow> {
+    ) : Iterable<AccountCollectionFlow> {
 
-        override fun iterator(): Iterator<AccountConnectionFlow> = iterator {
+        override fun iterator(): Iterator<AccountCollectionFlow> = iterator {
             var page = firstPage
             var index = 0
             while (true) {
@@ -207,7 +207,7 @@ private constructor(
             }
         }
 
-        fun stream(): Stream<AccountConnectionFlow> {
+        fun stream(): Stream<AccountCollectionFlow> {
             return StreamSupport.stream(spliterator(), false)
         }
     }

--- a/modern-treasury-java-core/src/main/kotlin/com/moderntreasury/api/models/AccountCollectionFlowListPageAsync.kt
+++ b/modern-treasury-java-core/src/main/kotlin/com/moderntreasury/api/models/AccountCollectionFlowListPageAsync.kt
@@ -26,7 +26,7 @@ private constructor(
 
     fun response(): Response = response
 
-    fun items(): List<AccountConnectionFlow> = response().items()
+    fun items(): List<AccountCollectionFlow> = response().items()
 
     fun perPage(): String = response().perPage()
 
@@ -102,7 +102,7 @@ private constructor(
     @NoAutoDetect
     class Response
     constructor(
-        private val items: JsonField<List<AccountConnectionFlow>>,
+        private val items: JsonField<List<AccountCollectionFlow>>,
         private val perPage: String,
         private val afterCursor: String,
         private val additionalProperties: Map<String, JsonValue>,
@@ -110,14 +110,14 @@ private constructor(
 
         private var validated: Boolean = false
 
-        fun items(): List<AccountConnectionFlow> = items.getNullable("items") ?: listOf()
+        fun items(): List<AccountCollectionFlow> = items.getNullable("items") ?: listOf()
 
         fun perPage(): String = perPage
 
         fun afterCursor(): String = afterCursor
 
         @JsonProperty("items")
-        fun _items(): Optional<JsonField<List<AccountConnectionFlow>>> = Optional.ofNullable(items)
+        fun _items(): Optional<JsonField<List<AccountCollectionFlow>>> = Optional.ofNullable(items)
 
         @JsonAnyGetter
         @ExcludeMissing
@@ -156,7 +156,7 @@ private constructor(
 
         class Builder {
 
-            private var items: JsonField<List<AccountConnectionFlow>> = JsonMissing.of()
+            private var items: JsonField<List<AccountCollectionFlow>> = JsonMissing.of()
             private var perPage: String? = null
             private var afterCursor: String? = null
             private var additionalProperties: MutableMap<String, JsonValue> = mutableMapOf()
@@ -169,10 +169,10 @@ private constructor(
                 this.additionalProperties.putAll(page.additionalProperties)
             }
 
-            fun items(items: List<AccountConnectionFlow>) = items(JsonField.of(items))
+            fun items(items: List<AccountCollectionFlow>) = items(JsonField.of(items))
 
             @JsonProperty("items")
-            fun items(items: JsonField<List<AccountConnectionFlow>>) = apply { this.items = items }
+            fun items(items: JsonField<List<AccountCollectionFlow>>) = apply { this.items = items }
 
             fun perPage(perPage: String) = apply { this.perPage = perPage }
 
@@ -199,11 +199,11 @@ private constructor(
     ) {
 
         fun forEach(
-            action: Predicate<AccountConnectionFlow>,
+            action: Predicate<AccountCollectionFlow>,
             executor: Executor
         ): CompletableFuture<Void> {
             fun CompletableFuture<Optional<AccountCollectionFlowListPageAsync>>.forEach(
-                action: (AccountConnectionFlow) -> Boolean,
+                action: (AccountCollectionFlow) -> Boolean,
                 executor: Executor
             ): CompletableFuture<Void> =
                 thenComposeAsync(
@@ -219,8 +219,8 @@ private constructor(
                 .forEach(action::test, executor)
         }
 
-        fun toList(executor: Executor): CompletableFuture<List<AccountConnectionFlow>> {
-            val values = mutableListOf<AccountConnectionFlow>()
+        fun toList(executor: Executor): CompletableFuture<List<AccountCollectionFlow>> {
+            val values = mutableListOf<AccountCollectionFlow>()
             return forEach(values::add, executor).thenApply { values }
         }
     }


### PR DESCRIPTION
The AccountCollectionFlow model/object (and related) were misnamed as AccountCo**nn**ectionFlow. This PR attempts to remedy this by simply renaming files and objects. Further testing may be required.